### PR TITLE
PerfExplore: Add the first cut of Flux PerfExplore

### DIFF
--- a/t/Makefile
+++ b/t/Makefile
@@ -1,0 +1,9 @@
+all: mpiusleep
+
+mpiusleep: mpiusleep.c
+	mpicc -O0 $^ -o $@
+
+.PHONY: clean
+
+clean:
+	rm -rf trash-directory* *.log mpiusleep instances* slurm-* t0001-sched-scale-*

--- a/t/README.md
+++ b/t/README.md
@@ -1,0 +1,186 @@
+## PerfExplore: Explore Performance and Scalability of Flux
+### 1. Background
+**Flux PerfExplore** is designed to explore the performance and scalability space
+of Flux. It varies each and all of the testing parameters and runs each
+configuration as a Flux instance launched in an allocation created by the native
+resource manager and scheduler.
+
+This project is work in progress as we started this effort as a means
+to execute our CTS-1 `flux-sched` testing plan described in distribution issue
+[#14](https://github.com/flux-framework/distribution/issues/14). However, the
+ultimate goal of **Flux PerfExplore** is to provide an automatic performance
+and scalability regression test suite for the various Flux projects. 
+
+### 2. Exploration Space
+The exploration space currently consists of 8 dimensions relevant in particular
+to scheduling: {NODES} x {BPN} x
+{Flux Scheduling Policies} x {Scheduling Queue Depths} x {Schduling Delay} x
+{MPI vs. Non-MPI usleep} x {Flux Job Counts} x {Flux Job Sizing Policies}.
+
+- **NODES**: Compute node counts to explore;
+- **BPN**: Brokers per node counts to explore (currently only set to 1);
+- **Flux Scheduling Policies**: Scheduling policies (currently, FCFS, EASY,
+    CONSERVATIVE, and HYBRID100);
+- **Scheduling Queue Depths**: Scheduler's pending-queue depth values
+     to explore; each value (val) is translated into
+     the `sched-params=queue-depth=val` scheduler load option;
+- **Scheduling Delay**: Scheduler's delay scheduling optimization
+     to explore (i.e., "true", "false" or "true false" -- each value (val)
+     of this space is used to explore `sched-params=delay-sched=val`);
+- **MPI vs. Non-MPI usleep**: Sleep with or without `MPI_Init()` and 
+    `MPI_Finalize()`;
+- **Flux Job Counts**: Flux job counts space to explore. Each count value
+    is the total number of jobs submited to the testing instance;
+- **Flux Job Sizing Policies**: Flux job size geometries to explore (i.e.,
+    unit (each job requesting 1 core), half (1/2 NODES cores), and power_2
+    (core count increases in powers-of-two, then wraps when it reaches it
+    its node count)).
+
+### 2. Driver
+
+`perfexplore.sh` is the driver which allows testers to pass in a range for each
+parameter space to explore. Once invoked, it computes each and all experiment
+points and submits them to the the native resource manager and scheduler. Once all
+instances are submitted, `perfexplore.sh` immediately exits with the following
+messages.
+
+
+```
+==================================================================
+ Done submitting. EXP_ID for this experiment: 1473974067.1097345282
+==================================================================
+```
+
+Here, `integer.integer` is the unique experiment ID (`EXP_ID`) with which
+**PerfExplore** associates the experiment. The first integer is
+the epoch since 1970-01-01 00:00:00 UTC and the second is a random number.
+Users can query the success and/or
+failure of each test instance by running `perfexplore.sh` with `-T` or
+`--tap-results` option with `EXP_ID` as its positional argument. The success or
+failure criteria of each instance is whether it has successfully completed
+within the target wall-clock time. Thus, users must ensure that all of the
+instances have completed before use `-T`. Results are printed in Test Anything
+Protocol (TAP).
+
+Even though the driver exits after the submits, as each instance successfully
+completes, its performance data files are stored in the specified directory for
+later inspection.
+
+### 3. Performance Data Files
+Each experiment stores the performance data files into
+`test-results-data/sched-scalability` or the directory specified with `-o` or
+`--output-dir` option. The following file-naming scheme is used.
+
+- Create two performance data files per instance:
+     - Suffix ending with in.stats contains perf per each 1000 jobs
+     - Suffix ending with ov.stats contains overall performance
+- Prefix concatenates each parameter of an instance as: 
+     - `W.R.NxB.s.c.p.q.d.j.m`, where each letter corresponding to a
+     short option above is replaced with the value used for the
+     instance.
+
+
+### 4. Example Experiment
+Running a **PerfExplore** experiment on LLNL's LC machine called `hype`:
+
+```
+hype356{dahn}93: perfexplore.sh --nnodes="2 4 8" --job-sizing="half" --codes="usleep" --sched-policies="FCFS" --njobs="1000 2000" ../../flux-stage/
+
+==================================================================
+ Submitting 6 flux instances to explore its performance space
+==================================================================
+msub -V -l nodes=2,walltime=10800 sched-scale-wrap.sh
+msub -V -l nodes=2,walltime=10800,depend=20892 sched-scale-wrap.sh ### debug comments
+msub -V -l nodes=4,walltime=10800,depend=20893 sched-scale-wrap.sh ### debug comments
+msub -V -l nodes=4,walltime=10800,depend=20894 sched-scale-wrap.sh ### debug comments
+msub -V -l nodes=8,walltime=10800,depend=20895 sched-scale-wrap.sh ### debug comments
+msub -V -l nodes=8,walltime=10800,depend=20896 sched-scale-wrap.sh ### debug comments
+==================================================================
+ Done submitting. EXP_ID for this experiment: 1473974919.3631007319
+==================================================================
+
+# Each msub command represents a test intance with a specific combination of parameters being explored
+# debug comments will show the values used for these parameters 
+# Once all of these jobs are finished
+```
+
+
+### 5. Querying the PerfExplore experiment PASS/FAIL results
+
+On the above experiment (EXP_ID: 1473974919.3631007319):
+
+```
+hype356{dahn}94: perfexplore.sh --tap-results 1473974919.3631007319
+
+==================================================================
+ Querying test results for EXP_ID=1473974919.3631007319
+==================================================================
+ok 1 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: size matches config
+ok 2 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: sched module loaded
+ok 3 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: persist fs attr matches
+ok 4 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: BPN matches config
+ok 5 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: run 1000 jobs in 10800 secs
+# passed all 5 test(s)
+1..5
+ok 1 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: size matches config
+ok 2 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: sched module loaded
+ok 3 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: persist fs attr matches
+ok 4 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: BPN matches config
+ok 5 - sched at MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: run 2000 jobs in 10800 secs
+# passed all 5 test(s)
+1..5
+ok 1 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: size matches config
+ok 2 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: sched module loaded
+ok 3 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: persist fs attr matches
+ok 4 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: BPN matches config
+ok 5 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: run 1000 jobs in 10800 secs
+# passed all 5 test(s)
+1..5
+ok 1 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: size matches config
+ok 2 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: sched module loaded
+ok 3 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: persist fs attr matches
+ok 4 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: BPN matches config
+ok 5 - sched at MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: run 2000 jobs in 10800 secs
+# passed all 5 test(s)
+1..5
+ok 1 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: size matches config
+ok 2 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: sched module loaded
+ok 3 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: persist fs attr matches
+ok 4 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: BPN matches config
+ok 5 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800: run 1000 jobs in 10800 secs
+# passed all 5 test(s)
+1..5
+ok 1 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: size matches config
+ok 2 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: sched module loaded
+ok 3 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: persist fs attr matches
+ok 4 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: BPN matches config
+ok 5 - sched at MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800: run 2000 jobs in 10800 secs
+# passed all 5 test(s)
+1..5
+==================================================================
+ Done the query. EXP_ID for this experiment: 1473975549.339076686
+==================================================================
+
+```
+
+### 5. Inspecting Performance Data Files
+ 
+```
+hype356{dahn}103: ls test-results-data/sched-scalability/ 
+MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800.in.stats
+MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800.in.stats
+MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800.ov.stats
+MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800.ov.stats
+MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800.in.stats
+MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800.in.stats
+MOAB.SLURM.00000002.00002Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800.ov.stats
+MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800.ov.stats
+MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800.in.stats
+MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800.in.stats
+MOAB.SLURM.00000004.00004Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00001000.10800.ov.stats
+MOAB.SLURM.00000008.00008Nx01B.half.usleep.FCFS.QD16.DELAYtrue.00002000.10800.ov.stats
+
+```
+
+### 6. More Information
+More information about PerfExplore's options can be found by typing in `perfexplore --help`.

--- a/t/mpiusleep.c
+++ b/t/mpiusleep.c
@@ -1,0 +1,20 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <mpi.h>
+
+int main (int argc, char *argv[])
+{
+    unsigned int usec = 0;
+    MPI_Init (&argc, &argv);
+    if (argc != 2) {
+        fprintf (stderr, "Usage: mpiusleep NUMBER\n");
+        fprintf (stderr, "  sleep some number of microseconds\n");
+        MPI_Finalize ();
+        exit (1);
+    }
+    usec = (unsigned int) atoi (argv[1]);
+    usleep (usec);
+    MPI_Finalize ();
+    return EXIT_SUCCESS;
+}

--- a/t/perfexplore.sh
+++ b/t/perfexplore.sh
@@ -1,0 +1,449 @@
+#!/bin/sh
+
+SCRIPT_NM="perfexplore.sh"
+SHORT_OPTSTR="p:q:d:j:s:c:N:B:m:R:W:P:l:o:Thy"
+SCHED_OPTS="sched-policies:,queue-depths:,delay:,njobs:,job-sizing:,codes:"
+SCAL_OPTS="nnodes:,nbrokers:,makespan:"
+CONF_OPTS="resource-mgr:,workload-mgr:,precedence:,limit:,output-dir:"
+QUERY_OPTS="tap-results"
+LONG_OPTSTR="${SCHED_OPTS},${SCAL_OPTS},${CONF_OPTS},${QUERY_OPTS},help,dry-run"
+
+# SCHED parameter space
+sched_policy_params="FCFS EASY CONSERVATIVE HYBRID100"
+sched_queue_depths="16"
+sched_delay="true"
+num_jobs_params="2000 10000"
+sizing_policy_params="unit half power_2"
+codes_params="usleep mpiusleep"
+
+# Scalability parameter space
+nnodes_params="2 4 8 16 32"
+bpn_params="1"
+duration=10800
+
+# Config
+RM="SLURM"
+WL="MOAB"
+PRECEDENCE="N B c s p q d j"
+REF_PRECEDENCE=${PRECEDENCE}
+THROTTLE=1
+DEP_JOBIDS=""
+NUM_PARA=0
+OUTPUT_DIR="test-results-data/sched-scalability"
+TAP_RESULTS=false
+EXP_ID=$(date +%s).$(od -N 4 -t uL -An /dev/urandom | tr -d " ")
+EXP_INST="instances"
+EXP_FILE=${EXP_INST}.${EXP_ID}
+
+# Utility
+DRY_RUN=false
+
+debug_params () {
+    echo "========= scheduling param space ================"
+    echo "sched_policy_params: ${sched_policy_params}"
+    echo "sched_queue_depths: ${sched_queue_depths}"
+    echo "sched_delay: ${sched_delay}"
+    echo "num_jobs_params: ${num_jobs_params}"
+    echo "sizing_policy_param: ${sizing_policy_params}"
+    echo "codes_params: ${codes_params}"
+    echo "========= scheduling scalability space =========="
+    echo "nnodes_params: ${nnodes_params}"
+    echo "bpn_params: ${bpn_params}"
+    echo "duration: ${duration}"
+    echo "==================== config ====================="
+    echo "RM: ${RM}"
+    echo "WL: ${WL}"
+    echo "PRECEDENCE: ${PRECEDENCE}"
+    echo "THROTTLE: ${THROTTLE}"
+    echo "OUTPUT_DIR: ${OUTPUT_DIR}"
+    echo "TAP_RESULTS: ${TAP_RESULTS}"
+    echo "EXP_ID: ${EXP_ID}"
+    echo "EXP_INST: ${EXP_INST}"
+    echo "EXP_FILE: ${EXP_FILE}"
+    echo ""
+}
+
+print_usage () {
+    cat <<EOF
+usage: perfexplore.sh [OPTIONS] FLUX_PATH|EXP_ID
+
+Explore flux-sched's performance/scalability space. It varies each
+and all of the testing parameters and runs each configuration as a
+flux instance launched in an allocation created by the native
+resource manager and scheduler (only SLURM and MOAB are supported
+for now).
+
+Write the performance data into test-results-data/sched-scalability
+directory or the directory specified with -o or --output-dir option,
+when each instance successfully completes.
+The file naming scheme of these data themselves is described in the
+Performance Data File Naming Scheme section below.
+
+Exit immediately after all instances are submitted.
+Users can see the success and/or failure by running this program
+with -T or --tap-results option with EXP_ID as the argument.
+Please ensure that all of the instances have completed before use
+-T. Results are printed in Test Anything Protocol (TAP).
+
+positional arguments:
+  FLUX_PATH                path to the root installation of flux
+  EXP_ID                   unique ID with which this program
+                             associates the experiment (printed by
+                             this program at the end).
+
+optional arguments  (scheduling parameters space to explore):
+ -p, --sched-policies=str  white-space-separated string to define
+                             flux scheduling policies to explore.
+                             "FCFS EASY" to explore FCFS and EASY
+                             backfill. (default to all available
+                             policies: ${sched_policy_params})
+ -q, --queue-depths=str    white-space-separated queue depth values
+                             each must be greater than 0
+                             (default: ${sched_queue_depths})
+ -d, --delay=str           white-space-separated delay scheduling
+                             space string, e.g., "true false".
+                             (default: ${sched_delay})
+ -j, --njobs=str           white-space-separated job counts space
+                             each must be greater than 1000
+                             (default: ${num_jobs_params})
+ -s, --job-sizing=str      white-space-separated job sizing
+                             policies (default to all available
+                             policies: ${sizing_policy_params})
+ -c, --codes               white-space-separated command names
+                             (default to all available codes:
+                             ${codes_params})
+
+optional arguments (sched scalability space to explore):
+ -N, --nnodes=str          white-space-separated compute-node counts
+                             each must be greater than 0
+                             (default: ${nnodes_params})
+ -B, --nbrokers=val        num of brokers to launch on each node
+                             (currently only 1 broker is supported)
+                             (default: ${bpn_params})
+
+optional arguments (performance target):
+ -m, --makespan=secs       wall clock time (secs) within which each
+                             run must complete
+                             (default: ${duration})
+
+optional arguments (configuration control):
+ -R, --resource-mgr=rm     native resource mgr (only SLURM for now)
+                             (default: ${RM})
+ -W, --workload-mgr=wm     native workload mgr (only MOAB for now)
+                             (default: ${WL})
+ -P, --precedence=str      order in which each parameter space is
+                             explored. str must be an ordered set of
+                             one or more parameter space coded by
+                             their short commandline options (e.g.,
+                             "N p" will vary all p parameter space
+                             before varying N parameter to the next
+                             (default: ${PRECEDENCE})
+ -l, --limit=val           limit the number of simultaneously running
+                             instances to val
+ -o, --output-dir=dir      directory to dump perf data (default:
+                             ${OUTPUT_DIR})
+ -T, --tap-results         print success and/or failure in TAP
+                             the positional argument must be EXP_ID
+
+optional arguments (utilities):
+ -h, --help                print this message
+ -y, --dry-run             don't run instances (only print submit
+                             commands)
+
+Performance Data File Naming Scheme:
+  Create two performance data files per instance:
+     Suffix ending with in.stats contains perf per each 1000 jobs
+     Suffix ending with ov.stats contains overall performance
+ Prefix concatenates each parameter of an instance as:
+     W.R.NxB.s.c.p.q.d.j.m, where each letter corresponding to a
+     short option above is replaced with the value used for the
+     instance.
+EOF
+    exit 1
+}
+
+member () {
+    local SET=${1}
+    local ELEM=${2}
+    local found=""
+    for s in ${SET};
+    do
+        if  test "${s}" = "${ELEM}";
+        then
+            return 0
+        fi 
+    done
+    return 1
+}
+
+valid_precedence () {
+    local P=${1}
+    local REF_P=${2}
+    for p in ${P};
+    do
+        member "${REF_P}" ${p}
+        if test $? -eq 1;
+        then
+            return 1
+        fi
+    done
+    return 0
+}
+
+precedence () {
+    local P=${1}
+    local REF_P=${2}
+    local RET_P=${P}
+
+    valid_precedence "${P}" "${REF_P}" 
+    if test $? -ne 0; 
+    then
+        return 1
+    fi
+
+    for rp in ${REF_P};
+    do 
+        member "${P}" "${rp}"
+        if test $? -eq 1;
+        then
+            RET_P="${RET_P} ${rp}"
+        fi
+    done
+    echo ${RET_P}
+    return 0
+}
+
+params () {
+    local pclass=${1}
+    local pset=""
+    case ${pclass} in
+        N) pset=${nnodes_params} ;; 
+        B) pset=${bpn_params} ;; 
+        c) pset=${codes_params} ;; 
+        s) pset=${sizing_policy_params} ;; 
+        p) pset=${sched_policy_params} ;; 
+        q) pset=${sched_queue_depths} ;; 
+        d) pset=${sched_delay} ;; 
+        j) pset=${num_jobs_params} ;; 
+        * ) echo <&2 "Unknown precedence letter ${pclass}" 
+    esac    
+    echo "${pset}"
+}
+
+expenv () {
+    local pclass=${1}
+    local param=${2}
+
+    case ${pclass} in
+        N) export SCAL_TST_NODES=${param} ;;
+        B) export SCAL_TST_BROKERS_PER_NODE=${param} ;;
+        c) export SCAL_TST_SLEEP_CMD=${param} ;;
+        s) export SCAL_TST_SIZING_POLICY=${param} ;;
+        p) export SCAL_TST_SCHED_POLICY=${param} ;;
+        q) export SCAL_TST_QUEUE_DEPTH=${param} ;;
+        d) export SCAL_TST_DELAY=${param} ;;
+        j) export SCAL_TST_NUM_JOBS=${param} ;;
+        *) echo <&2 "Unknown precedence letter ${pclass}" ;;
+    esac    
+} 
+
+fake_id=1234
+debug_comment () {
+    local sched="SCAL_TST_SCHED_POLICY=${SCAL_TST_SCHED_POLICY}" 
+    sched="${sched};SCAL_TST_QUEUE_DEPTH=${SCAL_TST_QUEUE_DEPTH}"
+    sched="${sched};SCAL_TST_DELAY=${SCAL_TST_DELAY}"
+    sched="${sched};SCAL_TST_SIZING_POLICY=${SCAL_TST_SIZING_POLICY}"
+    sched="${sched};SCAL_TST_SLEEP_CMD=${SCAL_TST_SLEEP_CMD}"
+    sched="${sched};SCAL_TST_NUM_JOBS=${SCAL_TST_NUM_JOBS}"
+    local conf="SCAL_TST_NODES=${SCAL_TST_NODES}"
+    conf="${conf};SCAL_TST_BROKERS_PER_NODE=${SCAL_TST_BROKERS_PER_NODE}"
+    echo "${sched};${conf}"
+}
+
+submit_instance () {
+    local comment=$(debug_comment)
+    local dep_id=""
+    local spec="nodes=${SCAL_TST_NODES},walltime=${SCAL_TST_TARGET}"
+
+    if test "${NUM_PARA}" != "${THROTTLE}";
+    then
+        echo "msub -V -l ${spec} sched-scale-wrap.sh ### ${comment}"
+        NUM_PARA=$((NUM_PARA+1))
+        if test "${DRY_RUN}" = "false";
+        then
+            dep_id=$(msub -V -l ${spec} sched-scale-wrap.sh) 
+            dep_id=$(echo $dep_id|tr -d '\n')
+        else
+            dep_id=${fake_id}
+            fake_id=$((fake_id+1))
+        fi
+        echo ${dep_id} >> ${EXP_FILE}
+        DEP_JOBID="${DEP_JOBID} ${dep_id}"
+    else
+        dep_id=$(echo ${DEP_JOBID} | cut -d ' ' -f1)
+        spec="${spec},depend=${dep_id}"
+
+        echo "msub -V -l ${spec} sched-scale-wrap.sh ### ${comment}"
+        if test "${DRY_RUN}" = "false";
+        then
+            dep_id=$(msub -V -l ${spec} sched-scale-wrap.sh) 
+            dep_id=$(echo $dep_id|tr -d '\n')
+        else
+            dep_id=${fake_id}
+            fake_id=$((fake_id+1))
+        fi
+        echo ${dep_id} >> ${EXP_FILE}
+
+        if test ${THROTTLE} != 1;
+        then
+            DEP_JOBID=$(echo ${DEP_JOBID} | cut -d ' ' -f2-)
+        else
+            DEP_JOBID=""
+        fi
+        DEP_JOBID="${DEP_JOBID} ${dep_id}"
+    fi
+}
+
+explore () {
+    local P=${1}
+    local p=""
+    local pclass=""
+
+    if test -z "${P}";
+    then
+        submit_instance 
+        return 0
+    fi
+    pclass=${P:0:1}
+    for p in $(params ${pclass});
+    do
+        expenv ${pclass} ${p}
+        explore "${P:2}" 
+    done
+    return 0
+}
+
+print_tap_results () {
+    file=${EXP_INST}.${1}
+    if ! test -f ${file};    
+    then
+        echo <&2 "Error: experiment file doesn't exist"
+        return 1
+    fi
+
+    echo "=================================================================="
+    echo " Querying test results for EXP_ID=${1}"
+    echo "=================================================================="
+
+    while read -r line; do
+       cat slurm-${line}.out
+       if test $? -ne 0;
+       then
+           echo <&2 "Error: slurm.${file} doesn't exist"
+           return 1
+       fi
+    done < ${file}
+
+    echo "=================================================================="
+    echo " Done the query. EXP_ID for this experiment: ${EXP_ID}"
+    echo "=================================================================="
+    return 0
+}
+
+
+############################################################################
+#                                 Main                                     #
+############################################################################
+
+OPTS=$(getopt -o ${SHORT_OPTSTR} -l ${LONG_OPTSTR} -n ${SCRIPT_NM} -- "$@")
+if test "$?" != 0;
+then
+    echo <&2 "Error: Failed parsing options." >&2
+    print_usage 
+fi
+eval set -- ${OPTS}
+while true;
+do
+    case "$1" in
+        -p | --sched-policies ) sched_policy_params="$2"; shift; shift ;;
+        -q | --queue-depths ) sched_queue_depths="$2"; shift; shift ;;
+        -d | --delay ) sched_delay="$2"; shift; shift ;;
+        -j | --njobs ) num_jobs_params="$2"; shift; shift ;;
+        -s | --job-sizing ) sizing_policy_params="$2"; shift; shift ;;
+        -c | --codes ) codes_params="$2"; shift; shift ;;
+        -N | --nnodes ) nnodes_params="$2"; shift; shift ;;
+        -B | --nbrokers ) bpn_params="$2"; shift; shift ;;
+        -m | --makespan ) duration="$2"; shift; shift ;;
+        -R | --resource-mgr ) RM="$2"; shift; shift ;;
+        -W | --workload-mgr ) WL="$2"; shift; shift ;;
+        -P | --precedence ) PRECEDENCE="$2"; shift; shift ;;
+        -l | --limit ) THROTTLE="$2"; shift; shift ;;
+        -o | --output-dir ) OUTPUT_DIR="$2"; shift; shift ;;
+        -T | --tap-results ) TAP_RESULTS=true; shift ;;
+        -h | --help ) print_usage; shift ;;
+        -y | --dry-run ) DRY_RUN=true; shift ;;
+        -- ) shift; break ;;
+        * ) break ;;
+    esac
+done
+
+
+posarg=${1:-0}
+
+if test $# -lt 1; 
+then
+    echo <&2 "Error: FLUX_PATH or EXP_ID not given"
+    print_usage
+fi
+
+if test "${TAP_RESULTS}" = "true";
+then
+    print_tap_results ${posarg}
+    exit $?
+fi
+
+if ! test -f "${posarg}/bin/flux"; then
+    echo <&2 "Error: ${posarg}/bin/flux doesn't exist"
+    print_usage
+else
+  fluxbin=$(readlink -e "${posarg}/bin/flux")
+  fluxdir=$(dirname ${fluxbin})
+  export PATH=${fluxdir}:${PATH}
+fi
+
+script_path=$(readlink -e $0)
+export SCAL_TST_BASEPATH=$(dirname $script_path)
+export SCAL_TST_WLM=MOAB
+export SCAL_TST_RM=SLURM
+export SCAL_TST_TARGET=${duration}
+export OUTPUT_DIR
+
+FQ_PRECEDENCE=$(precedence "${PRECEDENCE}" "${REF_PRECEDENCE}")
+if test $? -ne 0;
+then 
+    echo <&2 "Error: Invalid PRECEDENCE? (${PRECEDENCE})" 
+    print_usage
+fi
+
+spp=$(echo ${sched_policy_params} | wc -w)
+sqd=$(echo ${sched_queue_depths} | wc -w)
+sd=$(echo ${sched_delay} | wc -w)
+njp=$(echo ${num_jobs_params} | wc -w)
+szpp=$(echo ${sizing_policy_params} | wc -w)
+cop=$(echo ${codes_params} | wc -w)
+np=$(echo ${nnodes_params} | wc -w)
+bpnp=$(echo ${bpn_params} | wc -w)
+dim=$((spp*sqd*sd*njp*szpp*cop*np*bpnp))
+
+touch ${EXP_FILE}
+echo "=================================================================="
+echo " Submitting ${dim} flux instances to explore its performance space"
+echo "=================================================================="
+
+explore "${FQ_PRECEDENCE}" 
+
+echo "=================================================================="
+echo " Done submitting. EXP_ID for this experiment: ${EXP_ID}"
+echo "=================================================================="
+
+# vi: ts=4 sw=4 expandtab

--- a/t/sched-scale-wrap.sh
+++ b/t/sched-scale-wrap.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if test -z ${SCAL_TST_BASEPATH}; then
+    echo <&2 "SCAL_TST_BASEPATH envVar must be passed"
+    exit 1
+fi
+
+cd ${SCAL_TST_BASEPATH}
+ln -s t0001-sched-scale.t t0001-sched-scale-${SLURM_JOBID}.t
+./t0001-sched-scale-${SLURM_JOBID}.t #--debug #--verbose
+
+# vi: ts=4 sw=4 expandtab

--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -1,0 +1,228 @@
+#!/usr/bin/lua
+--
+--  waitfile.lua : Wait until a named file appears and contains a pattern
+--
+local usage = [[
+Usage: waitfile.lua [OPTIONS] FILE
+
+Wait for FILE to appear with optional pattern and number of lines.
+
+Options:
+ -h, --help       Display this message
+ -q, --quiet      Do not print file lines on stdout
+ -v, --verbose    Print extra information about program operation
+ -p, --pattern=P  Only match lines with Lua pattern P. Default is the
+                  empty pattern (therefore anything or nothing matches)
+ -c, --count=N    Wait until pattern has matched on N lines (Default: 1)
+ -t, --timeout=T  Timeout and exit with nonzero status after T seconds.
+                  (Default is to wait forever)
+ -P, --plugin=F   Load a plugin from file F or stdin if F is `-'. The plugin
+                  can register its own callbacks with flux handle `f'
+]]
+
+local getopt = require 'flux.alt_getopt' .get_opts
+local posix  = require 'flux.posix'
+local flux   = require 'flux'
+local timer  = require 'flux.timer'
+
+local opts, optind = getopt (arg, "hvqc:t:p:P:",
+                             { timeout = 't',
+                               pattern = 'p',
+                               plugin = 'P',
+                               count = 'c',
+                               quiet = 'q',
+                               verbose = 'v',
+                               help = 'h'
+                             })
+if opts.h then print (usage); os.exit (0) end
+
+local f, err = flux.new()
+if not f then error (err) end
+
+local timeout = tonumber (opts.t or 0)
+local pattern = opts.p or ""
+local count = opts.c or 1
+local file = arg[optind]
+local plugin = opts.P
+
+local tt = timer.new()
+
+local function printf (m, ...)
+    io.stderr:write (string.format ("waitfile: %s: %4.03fs: "..m, file, tt:get0(), ...))
+end
+
+local function log_verbose (m, ...)
+    if opts.v then
+        printf (m, ...)
+    end
+end
+
+if not timeout or not pattern or not file then
+    io.stderr:write (usage)
+    os.exit (1)
+end
+
+local filewatcher = {}
+filewatcher.__index = filewatcher
+
+function filewatcher:check_line (line)
+    if line:match (self.pattern) then
+        self.nmatch = self.nmatch + 1
+        log_verbose ("Got match (%d/%d)\n", self.nmatch, self.count)
+        return self.nmatch == self.count
+    end
+    return false
+end
+
+function filewatcher:checklines ()
+    if self.st.st_size == 0 then
+        -- Check if empty file is a match
+        return self:check_line ("")
+    end
+
+    local fp, err = io.open (self.filename, "r")
+    if not fp then return nil, err end
+    local p, err = fp:seek ("set", self.position)
+    log_verbose ("%s seek set to %d\n", self.filename, self.position)
+    for line in fp:lines() do
+        if self.printlines then io.stdout:write (line.."\n") end
+        if self:check_line (line) then
+            return true
+        end
+    end
+    self.position = fp:seek()
+    log_verbose ("leaving checklines() position=%d\n", self.position)
+    return false
+end
+
+-- Make older posix stat table look like new
+local stat = {
+ __index = function (t, k)
+    local k2 = k:match ("st_(.+)")
+    local v = rawget (t, k)
+    return v and v or rawget (t, k2)
+ end
+}
+
+function filewatcher:changed ()
+    local st = self.st
+    local prev = self.prev
+    if not st then
+        log_verbose ("No file yet\n")
+        return false
+    end
+    if not prev then
+        log_verbose ("File appeared with size %d\n", st.st_size)
+        return true
+    end
+    log_verbose ("File changed size %d\n", st.st_size)
+    if st.st_size < prev.st_size then
+        printf ("truncated!\n")
+        self.position = 0 -- reread
+    end
+    return true
+end
+
+function filewatcher:check ()
+    if self:changed () and self:checklines () then
+        log_verbose ("Got match. Calling self:on_match()\n")
+        self:on_match ()
+        return true
+    end
+    self.prev = self.st
+    return false
+end
+
+function filewatcher:start ()
+    self.flux:statwatcher {
+        path = self.filename,
+        interval = self.interval,
+        handler = function (w, st, prev)
+            log_verbose ("wakeup\n")
+            self.st = setmetatable (st, stat)
+            self:check ()
+            log_verbose ("back to sleep\n")
+        end
+    }
+    --  Be sure to call initial stat(2) *after*
+    --  statwatcher is started above, to avoid any race
+    local st = posix.stat (self.filename)
+    if st then
+        self.st = setmetatable (st, stat)
+    end
+    self:check ()
+end
+
+setmetatable (filewatcher, { __call = function (t, arg)
+    if not arg.filename or not arg.pattern then
+        return nil, "Error: required argument missing"
+    end
+    if not arg.flux then
+        return nil, "Error: flux handle missing"
+    end
+    local w = {
+        flux =     arg.flux,
+        filename = arg.filename,
+        pattern  = arg.pattern,
+	    count    = tonumber (arg.count) or 1,
+        interval = arg.interval and arg.interval or .25,
+        on_match = arg.on_match,
+        position = 0,
+        nmatch   = 0,
+        printlines =  not arg.quiet,
+    }
+    setmetatable (w, filewatcher)
+    if not w.on_match then
+        w.on_match = function ()
+	    log_verbose ("Exiting\n")
+            os.exit (0)
+        end
+    end
+    return w
+end
+})
+
+local fw, err = filewatcher { flux = f,
+                              filename = file,
+                              pattern = pattern,
+                              count = count,
+                              quiet = opts.q }
+if not fw then printf ("%s\n", err); os.exit (1) end
+
+-- Exit with non-zero status after timeout:
+--
+if timeout > 0 then
+    f:timer {
+      timeout = timeout * 1000,
+      handler = function ()
+        printf ("Timeout after %ds\n", timeout)
+        os.execute ("ls -l "..file)
+        os.exit (1)
+      end
+    }
+end
+
+
+-- open and execute a plugin file provided on cmdline
+if plugin then
+    local file
+    if plugin == "-" then
+        file = io.stdin
+    else
+        local f,err = io.open (plugin, "r")
+        if not f then error (err) end
+        file = f
+    end
+    local code = file:read ("*a")
+    local fn, err = loadstring ("local f, printf = ...; " .. code);
+    if not fn then error (err) end
+    setfenv (fn, _G)
+    local r, v = pcall (fn, f, printf)
+    if not r then error (v) end
+end
+
+-- Start reactor to do the work. It is an error if we exit the reactor.
+fw:start ()
+f:reactor ()
+printf ("Unexpectedly exited reactor\n")
+os.exit (1)

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -1,0 +1,101 @@
+
+#
+#  project-local sharness code for Flux
+#
+
+#
+#  Extra functions for Flux testsuite
+#
+run_timeout() {
+    perl -e 'alarm shift @ARGV; exec @ARGV' "$@"
+}
+
+#
+#  Echo on stdout a reasonable size for a large test session,
+#   controllable test-wide via env vars FLUX_TEST_SIZE_MIN and
+#   FLUX_TEST_SIZE_MAX.
+#
+test_size_large() {
+    min=${FLUX_TEST_SIZE_MIN:-4}
+    max=${FLUX_TEST_SIZE_MAX:-17}
+    size=$(($(nproc)+1))
+    test ${size} -lt ${min} && size=$min
+    test ${size} -gt ${max} && size=$max
+    echo ${size}
+}
+
+#
+#  Reinvoke a test file under a flux comms instance
+#
+#  Usage: test_under_flux <size>
+#
+test_under_flux() {
+    size=${1:-1}
+    personality=${2:-full}
+    log_file="$TEST_NAME.broker.log"
+    if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
+        cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
+        return
+    fi
+    quiet="-o -q,-Slog-filename=${log_file},-Slog-forward-level=7"
+    if test "$verbose" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
+        flags="${flags} --verbose"
+        quiet=""
+    fi
+    if test "$debug" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
+        flags="${flags} --debug"
+    fi
+    if test -n "$logfile" -o -n "$FLUX_TESTS_LOGFILE" ; then
+        flags="${flags} --logfile"
+    fi
+    if test -n "$SHARNESS_TEST_DIRECTORY"; then
+        cd $SHARNESS_TEST_DIRECTORY
+    fi
+
+    if test "$personality" = "minimal"; then
+        export FLUX_RC1_PATH=""
+        export FLUX_RC3_PATH=""
+    elif test "$personality" != "full"; then
+        export FLUX_RC1_PATH=$FLUX_SOURCE_DIR/t/rc/rc1-$personality
+        export FLUX_RC3_PATH=""
+        test -x $FLUX_RC1_PATH || error "$FLUX_RC1_PATH"
+    else
+        unset FLUX_RC1_PATH
+        unset FLUX_RC3_PATH
+    fi
+
+    TEST_UNDER_FLUX_ACTIVE=t \
+    TERM=${ORIGINAL_TERM} \
+      exec flux start --size=${size} ${quiet} "sh $0 ${flags}"
+}
+
+mock_bootstrap_instance() {
+    if test -z "${TEST_UNDER_FLUX_ACTIVE}"; then
+        unset FLUX_URI
+    fi
+}
+
+#
+#  Execute arguments $2-N on rank or ranks specified in arg $1
+#   using the flux-exec utility
+#
+test_on_rank() {
+    test "$#" -ge 2 ||
+        error "test_on_rank expects at least two parameters"
+    test -n "$TEST_UNDER_FLUX_ACTIVE"  ||
+        error "test_on_rank: test_under_flux not active ($TEST_UNDER_FLUX_ACTIVE)"
+
+    ranks=$1; shift;
+    flux exec --rank=${ranks} "$@"
+}
+
+#  Export a shorter name for this test
+TEST_NAME=$SHARNESS_TEST_NAME
+export TEST_NAME
+
+#  Test requirements for testsuite
+if ! lua -e 'require "posix"'; then
+    error "failed to find lua posix module in path"
+fi
+
+# vi: ts=4 sw=4 expandtab

--- a/t/sharness.d/scal-setup.sh
+++ b/t/sharness.d/scal-setup.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+#set -x
+
+error_exit() {
+    msg=${1:-Error}
+    echo >&2 $msg
+    exit 1
+} 
+
+#
+# print_w_leading_zeroes num [digits] 
+#     num: a positive integer, whose digit count must be less than or equal to max
+#     digits: the num of digits to print (e.g., digits=2, num=3 will print 03). 
+#             default is 8 and must not be greater than 8
+#
+print_w_leading_zeroes() {
+    n=${1:-1}
+    m=${2:-8}
+    if test $n -lt 0 -o ${#n} -gt $m -o $m -gt 8; then
+        error_exit "print_w_leading_zeroes: bad input"
+    fi
+    while test ${#n} -ne $m;
+    do
+        n="0"$n
+    done
+    echo "$n"
+}
+
+flux --help >/dev/null 2>&1 || error_exit "Failed to find flux in PATH"
+
+#
+# A bunch of environment variables should be set by the upper level script. 
+# However, for a case where some variables are missing, 
+# this script tries to pick default values to these variables. 
+#
+SCAL_TST_WLM=${SCAL_TST_WLM:-MOAB}
+SCAL_TST_RM=${SCAL_TST_RM:-SLURM}
+SCAL_TST_NODES=${SCAL_TST_NODES:-1}
+SCAL_TST_BROKERS_PER_NODE=${SCAL_TST_BROKERS_PER_NODE:-$SCAL_TST_NODES}
+SCAL_TST_SLEEP_CMD=${SCAL_TST_SLEEP_CMD:-usleep}
+SCAL_TST_SIZING_POLICY=${SCAL_TST_SIZING_POLICY:-unit}
+SCAL_TST_PERSIST_FS=${SCAL_TST_PERSIST_FS:-/nfs/tmp2/$USER}
+SCAL_TST_RESULTS_DIR=$SHARNESS_TEST_SRCDIR/$OUTPUT_DIR
+mkdir -p ${SCAL_TST_RESULTS_DIR}
+SCAL_TST_NUM_JOBS=${SCAL_TST_NUM_JOBS:-10000}
+SCAL_TST_TARGET=${SCAL_TST_TARGET:-3600}
+
+case $SCAL_TST_RM  in
+    SLURM|slurm)
+    DFLT_REXEC_STR="srun -N${SCAL_TST_NODES} \
+--ntasks-per-node=${SCAL_TST_BROKERS_PER_NODE}"
+    ;;
+    *)
+    echo >&2 "Unsupported resource manager."
+    exit 1
+    ;;
+esac
+
+SCAL_TST_REXEC_STR=${SCAL_TST_REXEC_STR:-$DFLT_REXEC_STR}
+
+SCAL_TST_SCHED_POLICY=${SCAL_TST_SCHED_POLICY:-fcfs}
+SCAL_TST_QUEUE_DEPTH=${SCAL_TST_QUEUE_DEPTH:-16}
+SCAL_TST_DELAY=${SCAL_TST_DELAY:-false}
+QD="sched-params=queue-depth=${SCAL_TST_QUEUE_DEPTH}"
+DL="delay-sched=${SCAL_TST_DELAY}"
+SCHED_PARAMS="${QD},${DL}"
+
+case $SCAL_TST_SCHED_POLICY in
+    fcfs|FCFS)
+    FLUX_SCHED_OPTIONS="${SCHED_PARAMS} plugin=sched.fcfs"
+    ;;
+    easy|EASY)
+    BACKFILL="plugin=sched.backfill plugin-opts=reserve-depth=1"
+    FLUX_SCHED_OPTIONS="${SCHED_PARAMS} ${BACKFILL}"
+    ;;
+    conservative|CONSERVATIVE)
+    BACKFILL="plugin=sched.backfill plugin-opts=reserve-depth=-1"
+    FLUX_SCHED_OPTIONS="${SCHED_PARAMS} ${BACKFILL}"
+    ;;
+    hybrid100|HYBRID100)
+    BACKFILL="plugin=sched.backfill plugin-opts=reserve-depth=100"
+    FLUX_SCHED_OPTIONS="${SCHED_PARAMS} ${BACKFILL}"
+    ;;
+    wreckrun|WRECKRUN)
+    FLUX_SCHED_RC_NOOP="yes"
+    ;;
+    *)
+    echo >&2 "Unknown scheduling policy: ${SCAL_TST_SCHED_POLICY}"
+    exit 1
+    ;;
+esac
+
+ENV_PAIR=${SCAL_TST_WLM}.${SCAL_TST_RM}
+WL_PAIR=${SCAL_TST_SIZING_POLICY}.${SCAL_TST_SLEEP_CMD}.${SCAL_TST_SCHED_POLICY}
+WL_PAIR=${WL_PAIR}.QD${SCAL_TST_QUEUE_DEPTH}.DELAY${SCAL_TST_DELAY}
+PAD_NODES=$(print_w_leading_zeroes $SCAL_TST_NODES 5)
+PAD_BPN=$(print_w_leading_zeroes $SCAL_TST_BROKERS_PER_NODE 2)
+BCOUNT=$((SCAL_TST_NODES*SCAL_TST_BROKERS_PER_NODE))
+PAD_BCOUNT=$(print_w_leading_zeroes $BCOUNT)
+PTP=$(print_w_leading_zeroes $SCAL_TST_NUM_JOBS 8).${SCAL_TST_TARGET}
+TST_CONFIG=${ENV_PAIR}.${PAD_BCOUNT}.${PAD_NODES}Nx${PAD_BPN}B.${WL_PAIR}.${PTP}
+SCAL_TST_CONFIG=${SCAL_TST_CONFIG:-$TST_CONFIG}
+
+export SCAL_TST_WLM
+export SCAL_TST_RM
+export SCAL_TST_NODES
+export SCAL_TST_BROKERS_PER_NODE
+export SCAL_TST_REXEC_STR
+export SCAL_TST_SLEEP_CMD
+export SCAL_TST_SIZING_POLICY
+export SCAL_TST_CONFIG
+export SCAL_TST_SCHED_POLICY
+export SCAL_TST_NUM_JOBS
+export SCAL_TST_TARGET
+export SCAL_TST_RESULTS_DIR
+export SCAL_TST_PERSIST_FS
+if ! test -z ${FLUX_SCHED_RC_NOOP}; then
+    export FLUX_SCHED_RC_NOOP
+    unset FLUX_SCHED_OPTIONS
+else
+    export FLUX_SCHED_OPTIONS
+fi
+
+# vi: ts=4 sw=4 expandtab

--- a/t/sharness.d/scal-sharness.sh
+++ b/t/sharness.d/scal-sharness.sh
@@ -1,0 +1,443 @@
+#
+# This test must be run with an installed flux-core and flux-sched
+#
+
+#
+# Internal file update routines
+#
+cp_results_file () {
+    local o=${1}
+    local dir=${2}
+    local caller=${3}
+    if test $# -ne 3; then
+        echo <&2 "${caller}: bad input"
+        return 1
+    elif ! test -f "${o}"; then
+        echo <&2 "${caller}: file doesn't exist: ${o}"
+        return 1
+    elif ! test -d "${dir}"; then
+        echo <&2 "${caller}: dir doesn't exist: ${dir}"
+        return 1
+    fi 
+    cp -f "${o}" "${dir}"
+    return $?
+}
+
+update_rawdata_header () {
+    local o="${1}.csv"
+    if test $# -ne 1; then
+        echo <&2 "update_rawdata_header: bad input"
+        return 1
+    fi
+    echo "jobid,s-time,r-time,c-time,nnodes,ntasks" > ${o}
+    return 0
+}
+
+update_rawdata () {
+    local o="${1}.csv"
+    local csv_fm="%s,%s,%s,%s,%s,%s"
+    if test $# -ne 7; then
+        echo <&2 "update_rawdata: bad input"
+        return 1
+    fi
+    printf "${csv_fm}\n" "$2" "$3" "$4" "$5" "$6" "$7" >> ${o}
+    return 0
+}
+
+cp_rawdata_file () {
+    local o="${1}.csv"
+    local dir=${2}
+    cp_results_file "${o}" "${dir}" "cp_rawdata_file"
+    return $?
+}
+
+update_ival_header () {
+    local o1="${1}.in.stats"
+    if test $# -ne 1; then
+        echo <&2 "update_ival_header: bad input"
+        return 1
+    fi
+    echo "job-group-id,used-nodes,job-count,JEPS" > $o1
+    return 0
+}
+
+update_ival_metrics () {
+    local o1="${1}.in.stats"
+    local gid=${2}
+    local njobs=${3}
+    local rout=${4}
+    local elapse=$(echo "${6}-${5}" | bc -l)
+    if test $# -ne 6; then
+        echo <&2 "update_ival_metrics: bad input"
+        return 1
+    fi
+
+    local usedcount=$(cat "${rout}" | cut -d'.' -f4 | sort | uniq | wc -l)
+    local JEPS=$(echo "${njobs}.0/${elapse}" | bc -l)
+    local fm="%s,%s,%s,%s"
+    printf "${fm}\n" "$gid" "$usedcount" "$njobs" "$JEPS" >> $o1
+    return $? 
+}
+
+cp_ival_metrics_file () {
+    local o="${1}.in.stats"
+    local dir=${2}
+    cp_results_file "${o}" "${dir}" "cp_ival_metrics_file"
+    return $?
+}
+
+update_ov_header () {
+    local o2="${1}.ov.stats"
+    if test $# -ne 1; then
+        echo <&2 "update_overall_header: bad input"
+        return 1
+    fi
+    echo "base-time,used-nodes,job-count,task-count,time-elapsed,JEPS,TEPS" > $o2
+    return 0
+}
+
+update_ov_metrics () {
+    local o2="${1}.ov.stats"
+    local njobs=${2}
+    local rout=${3}
+    local taskcnt=${4}
+    local e2e_elapse=$(echo "${6}-${5}" | bc -l)
+    local job_elapse=$(echo "${8}-${7}" | bc -l)
+    if test $# -ne 8; then
+        echo <&2 "update_overall_metrics: bad input"
+        return 1
+    fi
+
+    local fm="%s,%s,%s,%s,%s,%s,%s"
+    local uc=$(cat "${rout}" | cut -d'.' -f4 | sort | uniq | wc -l)
+    local JEPS=$(echo "${njobs}.0/${job_elapse}" | bc -l)
+    local TEPS=$(echo "${taskcnt}.0/${job_elapse}" | bc -l)
+    printf "${fm}\n" "elapse-time" "$uc" "$njobs" "$taskcnt" "$job_elapse" "$JEPS" "$TEPS" >> $o2
+    JEPS=$(echo "${njobs}.0/${e2e_elapse}" | bc -l)
+    TEPS=$(echo "${taskcnt}.0/${e2e_elapse}" | bc -l)
+    printf "${fm}\n" "e2e-time" "$uc" "$njobs" "$taskcnt" "$e2e_elapse" "$JEPS" "$TEPS" >> $o2
+    return $?
+}
+
+cp_ov_metrics_file () {
+    local o="${1}.ov.stats"
+    local dir=${2}
+    cp_results_file "${o}" "${dir}" "cp_ov_metrics_file"
+    return $?
+}
+
+#
+# Internal variables for test session management 
+#
+sched_instance_size=0
+sched_test_session=0
+sched_start_jobid=0
+sched_end_jobid=0
+
+# PUBLIC:
+#   Accessors 
+#
+get_instance_size () {
+    if test "${sched_instance_size}" = "0"; then
+        sched_instance_size=$(flux getattr size)
+    fi
+    echo "${sched_instance_size}"
+}
+
+get_session () {
+    echo "${sched_test_session}"
+}
+
+get_start_jobid () {
+    echo "${sched_start_jobid}"
+}
+
+get_end_jobid () {
+    echo "${sched_end_jobid}"
+}
+
+adjust_session_info () {
+    local njobs=${1}
+    sched_test_session=$((sched_test_session + 1))
+    sched_start_jobid=$((sched_end_jobid + 1))
+    sched_end_jobid=$((sched_start_jobid + njobs - 1))
+    return 0
+}
+
+# PUBLIC:
+#   Run flux-jstat in background. Wait up to 2 seconds 
+#   until flux-jstat gets ready to receive JSC events. 
+#   jstat's output will be printed to $1.<session_id>
+#
+timed_run_flux_jstat () {
+    local fn=${1}
+    ofile="${fn}.${sched_test_session}"
+    rm -f "${ofile}"
+    flux jstat -o "${ofile}" notify >/dev/null &
+    echo $! &&
+    ${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua --timeout 2 ${ofile} >&2
+}
+
+# PUBLIC:
+#   Run flux-waitjob in background. Wait up to $1 seconds
+#   until flux-waitjob gets ready to receive JSC events. 
+#   waitjob creates wo.st.<session_id> to signal its readiness
+#   and wo.end.<session_id> to indicate the specified job
+#   has completed.
+#
+timed_wait_job () {
+    local tout=${1}
+    flux waitjob -s wo.st.${sched_test_session} \
+         -c wo.end.${sched_test_session} ${sched_end_jobid} &
+    ${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua --timeout ${tout} \
+        wo.st.${sched_test_session} >&2
+    return $?
+}
+
+# PUBLIC:
+#   Wait up to $1 seconds until the previously invoked flux-waitjob
+#   detects the final job has completed.
+#
+timed_sync_wait_job () {
+    local tout=${1}
+    ${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua --timeout ${tout} \
+        wo.end.${sched_test_session} >&2
+    return $?
+}
+
+next_power_2_cores () {
+    local cores=${1}
+    cores=$((cores*2))
+    if test ${cores} -gt ${2}; then
+        cores=1 
+    fi
+    echo "${cores}" 
+} 
+
+# PUBLIC:
+#   Submit unit jobs.
+#     $1: sleep or mpisleep 
+#     $2: unit, half, power_2
+#     $3: nnodes 
+#
+submit_sleep_jobs () {
+    local ex=${1:-usleep}
+    local s=${2:-unit}
+    local nnodes=${3:-1}
+    local cores=1
+    local taskcount=0
+    
+    if test ${nnodes} -lt 1; then
+        echo <&2 "submit_sleep_jobs: bad input"
+        return 1
+    elif test "${ex}" != "usleep" -a ${ex} != "mpiusleep"; then
+        echo <&2 "submit_sleep_jobs: unknown sleep command"
+        return 1
+    elif test "${s}" != "unit" -a "${s}" != "half" -a "${s}" != "power_2"; then
+        echo <&2 "submit_sleep_jobs: unknown job sizing policy"
+        return 1
+    fi
+
+    if test "${s}" = "half"; then
+        if test ${nnodes} -gt 1; then
+            cores=$((nnodes/2)) 
+        else
+            echo <&2 "submit_sleep_jobs: nnodes must be greater than 1"
+            return 1 
+        fi
+    fi
+
+    for i in `seq ${sched_start_jobid} ${sched_end_jobid}`
+    do
+        taskcount=$((taskcount+cores))
+        flux submit -n "${cores}" "${ex}" 0
+        #usleep 10000
+        if test $? -ne 0; then
+            echo <&2 "flux submit failed"
+            return 1
+        fi
+        if test "${s}" = "power_2"; then
+            cores=$(next_power_2_cores ${cores} ${nnodes})
+        fi
+    done
+    local rc=$?
+    echo "${taskcount}"
+    return ${rc}
+} 
+
+# PUBLIC:
+#   Run unit jobs.
+#     $1: sleep or mpisleep 
+#     $2: unit, half, power_2
+#     $3: nnodes 
+#
+wreckrun_sleep_jobs () {
+    local ex=${1:-usleep}
+    local s=${2:-unit}
+    local nnodes=${3:-1}
+    local cores=1
+    local taskcount=0
+    
+    if test ${nnodes} -lt 1; then
+        echo <&2 "wreckrun_sleep_jobs: bad input"
+        return 1
+    elif test "${ex}" != "usleep" -a "${ex}" != "mpiusleep"; then
+        echo <&2 "wreckrun_sleep_jobs: unknown sleep command"
+        return 1
+    elif test "${s}" != "unit" -a "${s}" != "half" -a "${s}" != "power_2"; then
+        echo <&2 "wreckrun_sleep_jobs: unknown job sizing policy"
+        return 1
+    fi
+
+    if test "${s}" = "half"; then
+        if test ${nnodes} -gt 1; then
+            cores=$((nnodes/2)) 
+        else
+            echo <&2 "wreckrun_sleep_jobs: nnodes must be greater than 1"
+            return 1 
+        fi
+    fi
+
+    for i in `seq ${sched_start_jobid} ${sched_end_jobid}`
+    do
+        taskcount=$((taskcount+cores))
+        flux wreckrun --detach -n "${cores}" "${ex}" 0
+        if test $? -ne 0; then
+            echo <&2 "flux wreckrun --detach failed"
+            return 1
+        fi
+        if test "${s}" = "power_2"; then
+            cores=$(next_power_2_cores ${cores} ${nnodes})
+        fi
+    done
+    local rc=$?
+    echo ${taskcount}
+    return ${rc}
+} 
+
+# PUBLIC:
+#   Fetch, compute and store timing information 
+#     $1: base output file name 
+#     $2: begin time to compute end-to-end timing
+#     $3: end time to compute end-to-end timiming
+#     $4: granularity to compute possible peformnace degradation overtime
+#         (e.g., passing 1000 asks this function to compute 
+#          performnace metrics for every seperate 1000 jobs
+#          in addition to overall performance metrics)
+#     $5: total number of tasks scheduled
+dump_timing_info () {
+    local o=${1}
+    local -a e2e_elapse=(${2} ${3})
+    local gran=${4}
+    local tasks=${5}
+
+    if test $# -ne 5; then
+        echo >&2 "dump_timing_info: incorrect arg count"
+        return 1
+    elif test ${gran} -gt $((sched_end_jobid - sched_start_jobid + 1)); then
+        echo >&2 "dump_timing_info: bad input" 
+        return 1
+    elif test $((e2e_elapse[1] - e2e_elapse[0])) -lt 0; then 
+        echo >&2 "dump_timing_info: end time is greter then begin time" 
+        return 1
+    elif test $((tasks)) -lt 1; then
+        echo >&2 "dump_timing_info: invalid total number of tasks"
+        return 1
+    fi
+
+    #update_rawdata_header ${o} &&
+    update_ival_header ${o} && update_ov_header ${o} || return 1
+
+    local rout="ranks.${sched_test_session}"
+    local ni=0 # normalized jobid 
+    local gid=0 # group id incremented at every $gran jobs
+    local njobs=0
+    local -a fx
+    local -a task_stat
+    # st[0] is the beginning time stamp 
+    # Its granularity is interval. st[1]'s granularity is 
+    # all of the jobs 
+    local -a st
+    st[0]=$(flux kvs get "lwj.${sched_start_jobid}.starting-time")
+    st[1]=${st[0]}
+
+    for i in `seq $((sched_start_jobid-1)) ${gran} ${sched_end_jobid}`
+    do
+        ni=$((i-sched_start_jobid))
+        if test $((ni%gran)) -eq $((gran-1)); then
+            fx[0]=$(flux kvs get "lwj.${i}.starting-time")
+            fx[1]=$(flux kvs get "lwj.${i}.running-time")
+            fx[2]=$(flux kvs get "lwj.${i}.complete-time")
+            fx[3]=$(flux kvs get "lwj.${i}.nnodes")
+            fx[4]=$(flux kvs get "lwj.${i}.ntasks")
+            flux kvs dir "lwj.${i}.rank" >> "${rout}.ts"
+
+            #update_rawdata "$o" ${i} \
+            #${fx[0]} ${fx[1]} ${fx[2]} ${fx[3]} ${fx[4]}
+
+            update_ival_metrics "$o" $((ni/gran)) ${gran} "${rout}.ts" \
+                ${st[0]} ${fx[2]}
+            cat "${rout}.ts" >> "${rout}"
+            rm -f "${rout}.ts"
+            st[0]=${fx[2]}
+        fi
+    done
+
+    if test -f "${rout}.ts"; then
+        njobs=$((ni%gran+1))
+        update_ival_metrics "$o" $((ni/gran)) ${njobs} "$rout.ts" \
+            ${st[0]} ${fx[2]}
+        cat "${rout.ts}" >> "${rout}"
+        rm -f "${rout.ts}"
+    fi  
+    
+    njobs=$((sched_end_jobid - sched_start_jobid + 1))
+    update_ov_metrics "$o" ${njobs} "$rout" ${tasks} \
+        ${e2e_elapse[0]} ${e2e_elapse[1]} ${st[1]} ${fx[2]} || return 1
+
+    #cp_rawdata_file ${o} ${SCAL_TST_RESULTS_DIR} && \
+    cp_ival_metrics_file ${o} ${SCAL_TST_RESULTS_DIR} && \
+            cp_ov_metrics_file ${o} ${SCAL_TST_RESULTS_DIR} || return 1
+}
+
+#  PUBLIC:
+#  Reinvoke a test file under a flux comms instance
+#  using the rexec command string passed in (e.g., "srun -N4 -n4").
+#
+#  Usage: test_under_flux_w_rexec <rexec string> 
+#
+test_under_flux_w_rexec () {
+    runcmd=${1:-1}
+    test_inst_name=${2:-""}
+    persist_fs=${3:-""}
+    log_file="${TEST_NAME}.${test_inst_name}.broker.log"
+
+    if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
+        cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
+        return
+    fi
+    quiet="-o -q,-Slog-filename=${log_file},-Slog-forward-level=7"
+    if test "$verbose" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
+        flags="${flags} --verbose"
+        quiet=""
+    fi
+    if test "$debug" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
+        flags="${flags} --debug"
+    fi
+    if test -n "$logfile" -o -n "$FLUX_TESTS_LOGFILE" ; then
+        flags="${flags} --logfile"
+    fi
+    if test -n "$SHARNESS_TEST_DIRECTORY"; then
+        cd $SHARNESS_TEST_DIRECTORY
+    fi
+    persist=""
+    if test "x${persist_fs}" != "x"; then
+        persist="-o -Spersist-filesystem=${persist_fs}"
+    fi
+
+    TEST_UNDER_FLUX_ACTIVE=t \
+    TERM=${ORIGINAL_TERM} \
+      exec $runcmd flux start ${quiet} ${persist} "sh $0 ${flags}"
+}
+
+# vi: ts=4 sw=4 expandtab

--- a/t/sharness.sh
+++ b/t/sharness.sh
@@ -1,0 +1,776 @@
+#!/bin/sh
+#
+# Copyright (c) 2011-2012 Mathias Lafeldt
+# Copyright (c) 2005-2012 Git project
+# Copyright (c) 2005-2012 Junio C Hamano
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses/ .
+
+# Public: Current version of Sharness.
+SHARNESS_VERSION="0.3.0"
+export SHARNESS_VERSION
+
+# Public: The file extension for tests.  By default, it is set to "t".
+: ${SHARNESS_TEST_EXTENSION:=t}
+export SHARNESS_TEST_EXTENSION
+
+# Keep the original TERM for say_color
+ORIGINAL_TERM=$TERM
+
+# For repeatability, reset the environment to a known state.
+LANG=C
+LC_ALL=C
+PAGER=cat
+TZ=UTC
+TERM=dumb
+EDITOR=:
+export LANG LC_ALL PAGER TZ TERM EDITOR
+unset VISUAL CDPATH GREP_OPTIONS
+
+# Line feed
+LF='
+'
+
+[ "x$ORIGINAL_TERM" != "xdumb" ] && (
+		TERM=$ORIGINAL_TERM &&
+		export TERM &&
+		[ -t 1 ] &&
+		tput bold >/dev/null 2>&1 &&
+		tput setaf 1 >/dev/null 2>&1 &&
+		tput sgr0 >/dev/null 2>&1
+	) &&
+	color=t
+
+while test "$#" -ne 0; do
+	case "$1" in
+        --logfile)
+                logfile=t; shift;;
+	-d|--d|--de|--deb|--debu|--debug)
+		debug=t; shift ;;
+	-i|--i|--im|--imm|--imme|--immed|--immedi|--immedia|--immediat|--immediate)
+		immediate=t; shift ;;
+	-l|--l|--lo|--lon|--long|--long-|--long-t|--long-te|--long-tes|--long-test|--long-tests)
+		TEST_LONG=t; export TEST_LONG; shift ;;
+	-h|--h|--he|--hel|--help)
+		help=t; shift ;;
+	-v|--v|--ve|--ver|--verb|--verbo|--verbos|--verbose)
+		verbose=t; shift ;;
+	-q|--q|--qu|--qui|--quie|--quiet)
+		# Ignore --quiet under a TAP::Harness. Saying how many tests
+		# passed without the ok/not ok details is always an error.
+		test -z "$HARNESS_ACTIVE" && quiet=t; shift ;;
+	--no-color)
+		color=; shift ;;
+	--root=*)
+		root=$(expr "z$1" : 'z[^=]*=\(.*\)')
+		shift ;;
+	*)
+		echo "error: unknown test option '$1'" >&2; exit 1 ;;
+	esac
+done
+
+if test -n "$color"; then
+	say_color() {
+		(
+		TERM=$ORIGINAL_TERM
+		export TERM
+		case "$1" in
+		error)
+			tput bold; tput setaf 1;; # bold red
+		skip)
+			tput setaf 4;; # blue
+		warn)
+			tput setaf 3;; # brown/yellow
+		pass)
+			tput setaf 2;; # green
+		info)
+			tput setaf 6;; # cyan
+		*)
+			test -n "$quiet" && return;;
+		esac
+		shift
+		printf "%s" "$*"
+		tput sgr0
+		echo
+		)
+	}
+else
+	say_color() {
+		test -z "$1" && test -n "$quiet" && return
+		shift
+		printf "%s\n" "$*"
+	}
+fi
+
+error() {
+	say_color error "error: $*"
+	EXIT_OK=t
+	exit 1
+}
+
+say() {
+	say_color info "$*"
+}
+
+test -n "$test_description" || error "Test script did not set test_description."
+
+if test "$help" = "t"; then
+	echo "$test_description"
+	exit 0
+fi
+
+exec 5>&1
+exec 6<&0
+if test "$verbose" = "t"; then
+	exec 4>&2 3>&1
+elif test "$logfile" = "t"; then
+        logfile=$(basename $0 .t).output
+        exec 4>${logfile} 3>&4
+else
+	exec 4>/dev/null 3>/dev/null
+fi
+
+test_failure=0
+test_count=0
+test_fixed=0
+test_broken=0
+test_success=0
+
+die() {
+	code=$?
+	if test -n "$EXIT_OK"; then
+		exit $code
+	else
+		echo >&5 "FATAL: Unexpected exit with code $code"
+		exit 1
+	fi
+}
+
+EXIT_OK=
+trap 'die' EXIT
+
+# Public: Define that a test prerequisite is available.
+#
+# The prerequisite can later be checked explicitly using test_have_prereq or
+# implicitly by specifying the prerequisite name in calls to test_expect_success
+# or test_expect_failure.
+#
+# $1 - Name of prerequiste (a simple word, in all capital letters by convention)
+#
+# Examples
+#
+#   # Set PYTHON prerequisite if interpreter is available.
+#   command -v python >/dev/null && test_set_prereq PYTHON
+#
+#   # Set prerequisite depending on some variable.
+#   test -z "$NO_GETTEXT" && test_set_prereq GETTEXT
+#
+# Returns nothing.
+test_set_prereq() {
+	satisfied_prereq="$satisfied_prereq$1 "
+}
+satisfied_prereq=" "
+
+# Public: Check if one or more test prerequisites are defined.
+#
+# The prerequisites must have previously been set with test_set_prereq.
+# The most common use of this is to skip all the tests if some essential
+# prerequisite is missing.
+#
+# $1 - Comma-separated list of test prerequisites.
+#
+# Examples
+#
+#   # Skip all remaining tests if prerequisite is not set.
+#   if ! test_have_prereq PERL; then
+#       skip_all='skipping perl interface tests, perl not available'
+#       test_done
+#   fi
+#
+# Returns 0 if all prerequisites are defined or 1 otherwise.
+test_have_prereq() {
+	# prerequisites can be concatenated with ','
+	save_IFS=$IFS
+	IFS=,
+	set -- $*
+	IFS=$save_IFS
+
+	total_prereq=0
+	ok_prereq=0
+	missing_prereq=
+
+	for prerequisite; do
+		case "$prerequisite" in
+		!*)
+			negative_prereq=t
+			prerequisite=${prerequisite#!}
+			;;
+		*)
+			negative_prereq=
+		esac
+
+		total_prereq=$(($total_prereq + 1))
+		case "$satisfied_prereq" in
+		*" $prerequisite "*)
+			satisfied_this_prereq=t
+			;;
+		*)
+			satisfied_this_prereq=
+		esac
+
+		case "$satisfied_this_prereq,$negative_prereq" in
+		t,|,t)
+			ok_prereq=$(($ok_prereq + 1))
+			;;
+		*)
+			# Keep a list of missing prerequisites; restore
+			# the negative marker if necessary.
+			prerequisite=${negative_prereq:+!}$prerequisite
+			if test -z "$missing_prereq"; then
+				missing_prereq=$prerequisite
+			else
+				missing_prereq="$prerequisite,$missing_prereq"
+			fi
+		esac
+	done
+
+	test $total_prereq = $ok_prereq
+}
+
+# You are not expected to call test_ok_ and test_failure_ directly, use
+# the text_expect_* functions instead.
+
+test_ok_() {
+	test_success=$(($test_success + 1))
+	say_color "pass" "ok $test_count - $@"
+	test -n "$logfile" && say >&3 "ok $test_count - $@"
+	test -n "$logfile" && printf "%s\n" "$*" >&3
+}
+
+test_failure_() {
+	test_failure=$(($test_failure + 1))
+	say_color error "not ok $test_count - $1"
+	test -n "$logfile" && say >&3 "not ok $test_count - $1"
+	shift
+	echo "$@" | sed -e 's/^/#	/'
+	test "$immediate" = "" || { EXIT_OK=t; exit 1; }
+}
+
+test_known_broken_ok_() {
+	test_fixed=$(($test_fixed + 1))
+	say_color error "ok $test_count - $@ # TODO known breakage vanished"
+	test -n "$logfile" && say >&3 "ok $test_count - $@ # TODO known breakage vanished"
+}
+
+test_known_broken_failure_() {
+	test_broken=$(($test_broken + 1))
+	say_color warn "not ok $test_count - $@ # TODO known breakage"
+	test -n "$logfile" && say >&3 "not ok $test_count - $@ # TODO known breakage"
+}
+
+# Public: Execute commands in debug mode.
+#
+# Takes a single argument and evaluates it only when the test script is started
+# with --debug. This is primarily meant for use during the development of test
+# scripts.
+#
+# $1 - Commands to be executed.
+#
+# Examples
+#
+#   test_debug "cat some_log_file"
+#
+# Returns the exit code of the last command executed in debug mode or 0
+#   otherwise.
+test_debug() {
+	test "$debug" = "" || eval "$1"
+}
+
+test_eval_() {
+	# This is a separate function because some tests use
+	# "return" to end a test_expect_success block early.
+	eval </dev/null >&3 2>&4 "$*"
+}
+
+test_run_() {
+	test_cleanup=:
+	expecting_failure=$2
+	test_eval_ "$1"
+	eval_ret=$?
+
+	if test -z "$immediate" || test $eval_ret = 0 || test -n "$expecting_failure"; then
+		test_eval_ "$test_cleanup"
+	fi
+	if test "$verbose" = "t" && test -n "$HARNESS_ACTIVE"; then
+		echo ""
+	fi
+	return "$eval_ret"
+}
+
+test_skip_() {
+	test_count=$(($test_count + 1))
+	to_skip=
+	for skp in $SKIP_TESTS; do
+		case $this_test.$test_count in
+		$skp)
+			to_skip=t
+			break
+		esac
+	done
+	if test -z "$to_skip" && test -n "$test_prereq" && ! test_have_prereq "$test_prereq"; then
+		to_skip=t
+	fi
+	case "$to_skip" in
+	t)
+		of_prereq=
+		if test "$missing_prereq" != "$test_prereq"; then
+			of_prereq=" of $test_prereq"
+		fi
+
+		say_color skip >&3 "skipping test: $@"
+		say_color skip "ok $test_count # skip $1 (missing $missing_prereq${of_prereq})"
+		: true
+		;;
+	*)
+		false
+		;;
+	esac
+}
+
+# Public: Run test commands and expect them to succeed.
+#
+# When the test passed, an "ok" message is printed and the number of successful
+# tests is incremented. When it failed, a "not ok" message is printed and the
+# number of failed tests is incremented.
+#
+# With --immediate, exit test immediately upon the first failed test.
+#
+# Usually takes two arguments:
+# $1 - Test description
+# $2 - Commands to be executed.
+#
+# With three arguments, the first will be taken to be a prerequisite:
+# $1 - Comma-separated list of test prerequisites. The test will be skipped if
+#      not all of the given prerequisites are set. To negate a prerequisite,
+#      put a "!" in front of it.
+# $2 - Test description
+# $3 - Commands to be executed.
+#
+# Examples
+#
+#   test_expect_success \
+#       'git-write-tree should be able to write an empty tree.' \
+#       'tree=$(git-write-tree)'
+#
+#   # Test depending on one prerequisite.
+#   test_expect_success TTY 'git --paginate rev-list uses a pager' \
+#       ' ... '
+#
+#   # Multiple prerequisites are separated by a comma.
+#   test_expect_success PERL,PYTHON 'yo dawg' \
+#       ' test $(perl -E 'print eval "1 +" . qx[python -c "print 2"]') == "4" '
+#
+# Returns nothing.
+test_expect_success() {
+	test "$#" = 3 && { test_prereq=$1; shift; } || test_prereq=
+	test "$#" = 2 || error "bug in the test script: not 2 or 3 parameters to test_expect_success"
+	export test_prereq
+	if ! test_skip_ "$@"; then
+		say >&3 "expecting success: $2"
+		if test_run_ "$2"; then
+			test_ok_ "$1"
+		else
+			test_failure_ "$@"
+		fi
+	fi
+	echo >&3 ""
+}
+
+# Public: Run test commands and expect them to fail. Used to demonstrate a known
+# breakage.
+#
+# This is NOT the opposite of test_expect_success, but rather used to mark a
+# test that demonstrates a known breakage.
+#
+# When the test passed, an "ok" message is printed and the number of fixed tests
+# is incremented. When it failed, a "not ok" message is printed and the number
+# of tests still broken is incremented.
+#
+# Failures from these tests won't cause --immediate to stop.
+#
+# Usually takes two arguments:
+# $1 - Test description
+# $2 - Commands to be executed.
+#
+# With three arguments, the first will be taken to be a prerequisite:
+# $1 - Comma-separated list of test prerequisites. The test will be skipped if
+#      not all of the given prerequisites are set. To negate a prerequisite,
+#      put a "!" in front of it.
+# $2 - Test description
+# $3 - Commands to be executed.
+#
+# Returns nothing.
+test_expect_failure() {
+	test "$#" = 3 && { test_prereq=$1; shift; } || test_prereq=
+	test "$#" = 2 || error "bug in the test script: not 2 or 3 parameters to test_expect_failure"
+	export test_prereq
+	if ! test_skip_ "$@"; then
+		say >&3 "checking known breakage: $2"
+		if test_run_ "$2" expecting_failure; then
+			test_known_broken_ok_ "$1"
+		else
+			test_known_broken_failure_ "$1"
+		fi
+	fi
+	echo >&3 ""
+}
+
+# Public: Run command and ensure that it fails in a controlled way.
+#
+# Use it instead of "! <command>". For example, when <command> dies due to a
+# segfault, test_must_fail diagnoses it as an error, while "! <command>" would
+# mistakenly be treated as just another expected failure.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1.. - Command to be executed.
+#
+# Examples
+#
+#   test_expect_success 'complain and die' '
+#       do something &&
+#       do something else &&
+#       test_must_fail git checkout ../outerspace
+#   '
+#
+# Returns 1 if the command succeeded (exit code 0).
+# Returns 1 if the command died by signal (exit codes 130-192)
+# Returns 1 if the command could not be found (exit code 127).
+# Returns 0 otherwise.
+test_must_fail() {
+	"$@"
+	exit_code=$?
+	if test $exit_code = 0; then
+		echo >&2 "test_must_fail: command succeeded: $*"
+		return 1
+	elif test $exit_code -gt 129 -a $exit_code -le 192; then
+		echo >&2 "test_must_fail: died by signal: $*"
+		return 1
+	elif test $exit_code = 127; then
+		echo >&2 "test_must_fail: command not found: $*"
+		return 1
+	fi
+	return 0
+}
+
+# Public: Run command and ensure that it succeeds or fails in a controlled way.
+#
+# Similar to test_must_fail, but tolerates success too. Use it instead of
+# "<command> || :" to catch failures caused by a segfault, for instance.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1.. - Command to be executed.
+#
+# Examples
+#
+#   test_expect_success 'some command works without configuration' '
+#       test_might_fail git config --unset all.configuration &&
+#       do something
+#   '
+#
+# Returns 1 if the command died by signal (exit codes 130-192)
+# Returns 1 if the command could not be found (exit code 127).
+# Returns 0 otherwise.
+test_might_fail() {
+	"$@"
+	exit_code=$?
+	if test $exit_code -gt 129 -a $exit_code -le 192; then
+		echo >&2 "test_might_fail: died by signal: $*"
+		return 1
+	elif test $exit_code = 127; then
+		echo >&2 "test_might_fail: command not found: $*"
+		return 1
+	fi
+	return 0
+}
+
+# Public: Run command and ensure it exits with a given exit code.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1   - Expected exit code.
+# $2.. - Command to be executed.
+#
+# Examples
+#
+#   test_expect_success 'Merge with d/f conflicts' '
+#       test_expect_code 1 git merge "merge msg" B master
+#   '
+#
+# Returns 0 if the expected exit code is returned or 1 otherwise.
+test_expect_code() {
+	want_code=$1
+	shift
+	"$@"
+	exit_code=$?
+	if test $exit_code = $want_code; then
+		return 0
+	fi
+
+	echo >&2 "test_expect_code: command exited with $exit_code, we wanted $want_code $*"
+	return 1
+}
+
+# Public: Compare two files to see if expected output matches actual output.
+#
+# The TEST_CMP variable defines the command used for the comparision; it
+# defaults to "diff -u". Only when the test script was started with --verbose,
+# will the command's output, the diff, be printed to the standard output.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1 - Path to file with expected output.
+# $2 - Path to file with actual output.
+#
+# Examples
+#
+#   test_expect_success 'foo works' '
+#       echo expected >expected &&
+#       foo >actual &&
+#       test_cmp expected actual
+#   '
+#
+# Returns the exit code of the command set by TEST_CMP.
+test_cmp() {
+	${TEST_CMP:-diff -u} "$@"
+}
+
+# Public: Schedule cleanup commands to be run unconditionally at the end of a
+# test.
+#
+# If some cleanup command fails, the test will not pass. With --immediate, no
+# cleanup is done to help diagnose what went wrong.
+#
+# This is one of the prefix functions to be used inside test_expect_success or
+# test_expect_failure.
+#
+# $1.. - Commands to prepend to the list of cleanup commands.
+#
+# Examples
+#
+#   test_expect_success 'test core.capslock' '
+#       git config core.capslock true &&
+#       test_when_finished "git config --unset core.capslock" &&
+#       do_something
+#   '
+#
+# Returns the exit code of the last cleanup command executed.
+test_when_finished() {
+	test_cleanup="{ $*
+		} && (exit \"\$eval_ret\"); eval_ret=\$?; $test_cleanup"
+}
+
+# Public: Schedule cleanup commands to be run unconditionally when all tests
+# have run.
+#
+# This can be used to clean up things like test databases. It is not needed to
+# clean up temporary files, as test_done already does that.
+#
+# Examples:
+#
+#   cleanup mysql -e "DROP DATABASE mytest"
+#
+# Returns the exit code of the last cleanup command executed.
+final_cleanup=
+cleanup() {
+	final_cleanup="{ $*
+		} && (exit \"\$eval_ret\"); eval_ret=\$?; $final_cleanup"
+}
+
+# Public: Summarize test results and exit with an appropriate error code.
+#
+# Must be called at the end of each test script.
+#
+# Can also be used to stop tests early and skip all remaining tests. For this,
+# set skip_all to a string explaining why the tests were skipped before calling
+# test_done.
+#
+# Examples
+#
+#   # Each test script must call test_done at the end.
+#   test_done
+#
+#   # Skip all remaining tests if prerequisite is not set.
+#   if ! test_have_prereq PERL; then
+#       skip_all='skipping perl interface tests, perl not available'
+#       test_done
+#   fi
+#
+# Returns 0 if all tests passed or 1 if there was a failure.
+test_done() {
+	EXIT_OK=t
+
+	if test -z "$HARNESS_ACTIVE"; then
+		test_results_dir="$SHARNESS_TEST_DIRECTORY/test-results"
+		mkdir -p "$test_results_dir"
+		test_results_path="$test_results_dir/${SHARNESS_TEST_NAME}.$$.counts"
+
+		cat >>"$test_results_path" <<-EOF
+		total $test_count
+		success $test_success
+		fixed $test_fixed
+		broken $test_broken
+		failed $test_failure
+
+		EOF
+	fi
+
+	if test "$test_fixed" != 0; then
+		say_color error "# $test_fixed known breakage(s) vanished; please update test(s)"
+		test -n "$logfile" && say >&3 "# $test_fixed known breakage(s) vanished"
+	fi
+	if test "$test_broken" != 0; then
+		say_color warn "# still have $test_broken known breakage(s)"
+		test -n "$logfile" && say >&3 "# still have $test_broken known breakage(s)"
+	fi
+	if test "$test_broken" != 0 || test "$test_fixed" != 0; then
+		test_remaining=$(( $test_count - $test_broken - $test_fixed ))
+		msg="remaining $test_remaining test(s)"
+	else
+		test_remaining=$test_count
+		msg="$test_count test(s)"
+	fi
+
+	case "$test_failure" in
+	0)
+		# Maybe print SKIP message
+		if test -n "$skip_all" && test $test_count -gt 0; then
+			error "Can't use skip_all after running some tests"
+		fi
+		[ -z "$skip_all" ] || skip_all=" # SKIP $skip_all"
+
+		if test $test_remaining -gt 0; then
+			say_color pass "# passed all $msg"
+			test -n "$logfile" && say >&3 "# passed all $msg"
+		fi
+		say "1..$test_count$skip_all"
+		test -n "$logfile" && say >&3 "1..$test_count$skip_all"
+
+		test_eval_ "$final_cleanup"
+
+		test -d "$remove_trash" &&
+		cd "$(dirname "$remove_trash")" &&
+		rm -rf "$(basename "$remove_trash")"
+
+		test -n "$logfile" &&
+		  test -f "$logfile" &&
+		  rm -f "${logfile}"
+
+		exit 0 ;;
+
+	*)
+		say_color error "# failed $test_failure among $msg"
+		say "1..$test_count"
+		if test -n "$logfile"; then
+			say >&3 "# failed $test_failure among $msg"
+			say >&3 "1..$test_count"
+		fi
+
+		exit 1 ;;
+
+	esac
+}
+
+# Public: Root directory containing tests. Tests can override this variable,
+# e.g. for testing Sharness itself.
+: ${SHARNESS_TEST_DIRECTORY:=$(pwd)}
+export SHARNESS_TEST_DIRECTORY
+
+#
+# Public: Source directory of test code and sharness library.
+#  This directory may be different from the directory in which tests are
+#  being run.
+: ${SHARNESS_TEST_SRCDIR:=$(cd `dirname $0` && pwd)}
+
+# Public: Build directory that will be added to PATH. By default, it is set to
+# the parent directory of SHARNESS_TEST_DIRECTORY.
+: ${SHARNESS_BUILD_DIRECTORY:="$SHARNESS_TEST_DIRECTORY/.."}
+PATH="$SHARNESS_BUILD_DIRECTORY:$PATH"
+export PATH SHARNESS_BUILD_DIRECTORY
+
+# Public: Path to test script currently executed.
+SHARNESS_TEST_FILE="$0"
+export SHARNESS_TEST_FILE
+
+SHARNESS_TEST_NAME=${SHARNESS_TEST_FILE##*/}
+SHARNESS_TEST_NAME=${SHARNESS_TEST_NAME%.${SHARNESS_TEST_EXTENSION}}
+
+# Prepare test area.
+test_dir="trash-directory.$SHARNESS_TEST_NAME"
+test -n "$root" && test_dir="$root/$test_dir"
+case "$test_dir" in
+/*) SHARNESS_TRASH_DIRECTORY="$test_dir" ;;
+ *) SHARNESS_TRASH_DIRECTORY="$SHARNESS_TEST_DIRECTORY/$test_dir" ;;
+esac
+test "$debug" = "t" || remove_trash="$SHARNESS_TRASH_DIRECTORY"
+rm -rf "$test_dir" || {
+	EXIT_OK=t
+	echo >&5 "FATAL: Cannot prepare test area"
+	exit 1
+}
+
+
+#
+#  Load any extensions in $srcdir/sharness.d/*.sh
+#
+if test -d "${SHARNESS_TEST_SRCDIR}/sharness.d"; then
+	for file in "${SHARNESS_TEST_SRCDIR}"/sharness.d/*.sh; do
+		if test -n "$debug"; then
+			echo 2>&1 "Attempting to load ${file}"
+		fi
+		. ${file}
+		if test $? != 0; then
+			echo 2>&1 "sharness: Error loading ${file}. Aborting."
+			exit 1
+		fi
+	done
+fi
+
+# Public: Empty trash directory, the test area, provided for each test. The HOME
+# variable is set to that directory too.
+export SHARNESS_TRASH_DIRECTORY
+
+HOME="$SHARNESS_TRASH_DIRECTORY"
+export HOME
+
+mkdir -p "$test_dir" || exit 1
+# Use -P to resolve symlinks in our working directory so that the cwd
+# in subprocesses like git equals our $PWD (for pathname comparisons).
+cd -P "$test_dir" || exit 1
+
+for skp in $SKIP_TESTS; do
+	case "$SHARNESS_TEST_NAME" in
+	$skp)
+		say_color info >&3 "skipping test $this_test altogether"
+		skip_all="skip all tests in $this_test"
+		test_done
+	esac
+done
+
+# vi: set ts=4 sw=4 noet :

--- a/t/t0001-sched-scale.t
+++ b/t/t0001-sched-scale.t
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+test_description='Run the basic scheduler scalability tests at: 
+    - System Workload Manager: ${SCAL_TST_WLM}
+    - System Resource Manager (REXEC): ${SCAL_TST_RM}
+    - Number of Compute Nodes: ${SCAL_TST_NODES} 
+    - Number of Brokers Per Node: ${SCAL_TST_BROKERS_PER_NODE}
+    - MPI vs Non-MPI: ${SCAL_TST_SLEEP_CMD}
+    - Job Sizing Policy: ${SCAL_TST_SIZING_POLICY}
+    - flux-sched Scheduling Policy: ${SCAL_TST_SCHED_POLICY}
+    - Queue depth: ${SCAL_TST_QUEUE_DEPTH}
+    - Delay: ${SCAL_TST_DELAY}
+
+Produce performance profiles; ensure that the basics
+of scalability tests work at this configuration.
+'
+
+#
+# source sharness from the directory where this test
+# file resides
+#
+. $(dirname $0)/sharness.sh
+
+#
+# test_under_flux_w_rexec is under sharness.d/
+#
+test_under_flux_w_rexec "${SCAL_TST_REXEC_STR}" "${SCAL_TST_CONFIG}" \
+    "${SCAL_TST_PERSIST_FS}"
+
+test_expect_success "sched at ${SCAL_TST_CONFIG}: size matches config" '
+    flux getattr size > size.out &&
+    sz=$(($SCAL_TST_NODES*$SCAL_TST_BROKERS_PER_NODE)) &&
+    test $(cat size.out) = $sz 
+'
+
+test_expect_success "sched at ${SCAL_TST_CONFIG}: sched module loaded" '
+    flux module list | egrep "hwloc|job|sched" > modules.out &&
+    test $(cat modules.out | wc -l) -eq 3 
+'
+
+test_expect_success "sched at ${SCAL_TST_CONFIG}: persist fs attr matches" '
+    echo "${SCAL_TST_PERSIST_FS}" &&
+    test -d "${SCAL_TST_PERSIST_FS}" &&
+    fs=$(flux getattr persist-filesystem)  &&
+    test "$fs" = "${SCAL_TST_PERSIST_FS}" 
+'
+
+test_expect_success "sched at ${SCAL_TST_CONFIG}: BPN matches config" '
+    adjust_session_info 1 &&
+    timed_wait_job 5 &&
+    flux submit -N ${SCAL_TST_NODES} --tasks-per-node=1 --output=h.out hostname &&
+    timed_sync_wait_job 2 &&
+    res=$(cat h.out | uniq -c | gawk '\''{print $1}'\'' | uniq | wc -l) &&
+    test $res -eq 1
+'
+
+MAIN_TST_MSG="run ${SCAL_TST_NUM_JOBS} jobs in ${SCAL_TST_TARGET} secs"
+test_expect_success "sched at ${SCAL_TST_CONFIG}: ${MAIN_TST_MSG}" '
+    adjust_session_info ${SCAL_TST_NUM_JOBS} &&
+    st_jobid=$(get_start_jobid)
+    gran=1000 &&
+    flux cron event -n ${gran} wreck.state.complete flux wreck purge -v -Rt 256 -k \'\''id-${st_jobid} == 0 or \(id-${st_jobid}+1\)%${gran} == 0\'\'' &&
+    timed_wait_job 5 &&
+    n=${SCAL_TST_NODES} &&
+    ts_begin=$(date +%s) && 
+    t=$(submit_sleep_jobs ${SCAL_TST_SLEEP_CMD} ${SCAL_TST_SIZING_POLICY} ${n}) &&
+    timed_sync_wait_job ${SCAL_TST_TARGET} &&
+    ts_end=$(date +%s) &&
+    dump_timing_info ${SCAL_TST_CONFIG} ${ts_begin} ${ts_end} ${gran} ${t} 
+'
+
+test_done


### PR DESCRIPTION
Add the first set of scripts, collectively called Flux PerfExplore:
- README.md documents the overall description of this tester
- The commit message of perfexplore.sh and ached-scale-wrap.sh describes the usage with `--help` option
- Extend sharness so that the test results can be printed in TAP 
